### PR TITLE
Clean up unused settings

### DIFF
--- a/src/settings/settingsdialog.h
+++ b/src/settings/settingsdialog.h
@@ -34,7 +34,6 @@ public:
 	static void copyDescriptions(QWidget *parent);
 
 	Field<AbstractUploader *> uploader;
-	Field<QUrl> homeUrl;
 	Field<bool> captionsUnder;
 	Field<bool> extraSpace;
 	Field<bool> numberImages;
@@ -42,7 +41,6 @@ public:
 	Field<bool> addImageBorder;
 	Field<bool> addTBC;
 	Field<int> imagesPerPost;
-	Field<int> postSpace;
 	Field<QString> extraTags;
 
 	Field<bool> setImageWidth;

--- a/src/widgets/replydialog.cpp
+++ b/src/widgets/replydialog.cpp
@@ -35,7 +35,7 @@ ReplyDialog::ReplyDialog(QSettings &settings, QList<AbstractImage *> imageList, 
 	foreach (AbstractImage *image, imageList)
 		images.append(image, 1.0, ui->progressBarImage);
 	for (int i = 0; i < qCeil((qreal)imageList.count() / SETTINGS->imagesPerPost); ++i)
-		posts.append(new PostWidget(ui->toolBox), SETTINGS->postSpace);
+		posts.append(new PostWidget(ui->toolBox));
 
 	posts.first()->setTotal(0);
 	posts.last()->object()->setLast();


### PR DESCRIPTION
After removal of forum-related inputs from Settings Dialog, there were some leftovers in class definition. Calling them was a cause of sudden crashes.