### PR TITLE
Get rid of Qt Script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,6 @@ jobs:
         with:
           version: "5.12.10"
           target: desktop
-          modules: "qtscript"
 
       - name: Write secrets
         run: |

--- a/fotorelacjonusz.pro
+++ b/fotorelacjonusz.pro
@@ -60,6 +60,7 @@ SOURCES += \
 	src/messagehandler.cpp \
 	src/exception.cpp \
 	src/application.cpp \
+	src/uploaders/imgurresponse.cpp \
 	src/widgets/threadedvalidator.cpp \
 	src/widgets/selectablewidget.cpp \
 	src/widgets/replydialog.cpp \
@@ -95,7 +96,6 @@ SOURCES += \
 	src/uploaders/networktransactionquery.cpp \
 	src/uploaders/networktransactionmultipart.cpp \
 	src/uploaders/networktransaction.cpp \
-	src/uploaders/jsonobject.cpp \
 	src/uploaders/isloginuploader.cpp \
 	src/uploaders/iscodeuploader.cpp \
 	src/uploaders/isanonuploader.cpp \
@@ -114,6 +114,7 @@ HEADERS += \
 	src/messagehandler.h \
 	src/exception.h \
 	src/application.h \
+	src/uploaders/imgurresponse.h \
 	src/widgets/threadedvalidator.h \
 	src/widgets/selectablewidget.h \
 	src/widgets/replydialog.h \
@@ -149,7 +150,6 @@ HEADERS += \
 	src/uploaders/networktransactionquery.h \
 	src/uploaders/networktransactionmultipart.h \
 	src/uploaders/networktransaction.h \
-	src/uploaders/jsonobject.h \
 	src/uploaders/isloginuploader.h \
 	src/uploaders/iscodeuploader.h \
 	src/uploaders/isanonuploader.h \

--- a/fotorelacjonusz.pro
+++ b/fotorelacjonusz.pro
@@ -15,7 +15,7 @@ QMAKE_TARGET_BUNDLE_PREFIX = org.forumpolskichwiezowcow
 # MacOS icon set
 ICON = appicon.icns
 
-QT += core gui network script widgets xml xmlpatterns
+QT += core gui network widgets xml xmlpatterns
 
 # Enable C++11 explicitly, which should make proper stdlib available.
 # Required to compile at least on OS X.

--- a/src/uploaders/imguranonuploader.cpp
+++ b/src/uploaders/imguranonuploader.cpp
@@ -1,6 +1,6 @@
 #include "imguranonuploader.h"
 #include "ui_imguranonuploader.h"
-#include "jsonobject.h"
+#include "imgurresponse.h"
 #include "networktransactionmultipart.h"
 #include "secrets.h"
 
@@ -53,7 +53,7 @@ QString ImgurAnonUploader::uploadImage(QString filePath, QIODevice *image)
 		tr.addHttpPart("album_id", albumId.toAscii());
 	tr.post();
 
-	JsonObject json(tr);
+	ImgurResponse json(tr);
 	error = json.mergedError;
 	image->close();
 	return json.success ? json.data["link"] : "";
@@ -70,7 +70,7 @@ void ImgurAnonUploader::updateCredits()
 	setAuthorization(&tr);
 	tr.get();
 	qDebug() << "credits updated";
-	JsonObject json(tr);
+	ImgurResponse json(tr);
 
 	credits.userLimit = json.data[USER_LIMIT_CSTR].toInt();
 	credits.userRemaining = json.data[USER_REMAINING_CSTR].toInt();

--- a/src/uploaders/imgurresponse.cpp
+++ b/src/uploaders/imgurresponse.cpp
@@ -1,4 +1,4 @@
-#include "jsonobject.h"
+#include "imgurresponse.h"
 #include "networktransaction.h"
 
 #include <QScriptEngine>
@@ -6,7 +6,7 @@
 #include <QStringList>
 #include <QDebug>
 
-JsonObject::JsonObject(const NetworkTransaction &tr):
+ImgurResponse::ImgurResponse(const NetworkTransaction &tr):
 	success(false),
 	status(0)
 {
@@ -51,7 +51,7 @@ JsonObject::JsonObject(const NetworkTransaction &tr):
 	mergedError = errors.join("\n");
 }
 
-void JsonObject::debug() const
+void ImgurResponse::debug() const
 {
 	QDebug debug(QtDebugMsg);
 	debug.nospace() << "{\n";

--- a/src/uploaders/imgurresponse.cpp
+++ b/src/uploaders/imgurresponse.cpp
@@ -10,6 +10,33 @@ ImgurResponse::ImgurResponse(const NetworkTransaction &tr):
 	success(false),
 	status(0)
 {
+	parseResponse(tr);
+}
+
+void ImgurResponse::debug() const
+{
+	QDebug debug(QtDebugMsg);
+	debug.nospace() << "{\n";
+	debug << "  success:     " << success << "\n";
+	debug << "  status:      " << status << "\n";
+	debug << "  error:       " << error << "\n";
+	debug << "  mergedError: " << mergedError << "\n";
+	debug << "  data:\n";
+	debug << "  {\n";
+	for (ParamMap::ConstIterator i = data.begin(); i != data.end(); ++i)
+		debug << "    " << i.key() << ":\t" << i.value() << "\n";
+	debug << "  }\n";
+	for (ParamMap::ConstIterator i = begin(); i != end(); ++i)
+		debug << "  " << i.key() << ":\t" << i.value() << "\n";
+	debug << "}\n";
+	debug.space();
+}
+
+/**
+ * @brief Parses network transaction which contains a JSON response from Imgur.
+ */
+void ImgurResponse::parseResponse(const NetworkTransaction &tr)
+{
 	QScriptEngine se;
 	QScriptValue val = se.evaluate("(" + tr.data + ")");
 
@@ -49,23 +76,4 @@ ImgurResponse::ImgurResponse(const NetworkTransaction &tr):
 		errors << data["message"];
 
 	mergedError = errors.join("\n");
-}
-
-void ImgurResponse::debug() const
-{
-	QDebug debug(QtDebugMsg);
-	debug.nospace() << "{\n";
-	debug << "  success:     " << success << "\n";
-	debug << "  status:      " << status << "\n";
-	debug << "  error:       " << error << "\n";
-	debug << "  mergedError: " << mergedError << "\n";
-	debug << "  data:\n";
-	debug << "  {\n";
-	for (ParamMap::ConstIterator i = data.begin(); i != data.end(); ++i)
-		debug << "    " << i.key() << ":\t" << i.value() << "\n";
-	debug << "  }\n";
-	for (ParamMap::ConstIterator i = begin(); i != end(); ++i)
-		debug << "  " << i.key() << ":\t" << i.value() << "\n";
-	debug << "}\n";
-	debug.space();
 }

--- a/src/uploaders/imgurresponse.h
+++ b/src/uploaders/imgurresponse.h
@@ -19,6 +19,9 @@ public:
 	int status;
 	QString error;
 	QString mergedError;
+
+private:
+	void parseResponse(const NetworkTransaction &tr);
 };
 
 #endif // JSONOBJECT_H

--- a/src/uploaders/imgurresponse.h
+++ b/src/uploaders/imgurresponse.h
@@ -6,6 +6,7 @@
 
 class NetworkTransaction;
 
+// TODO: Make it <QString, QVariant> to avoid unnecessary data conversions.
 typedef QMap<QString, QString> ParamMap;
 
 class ImgurResponse : public ParamMap

--- a/src/uploaders/imgurresponse.h
+++ b/src/uploaders/imgurresponse.h
@@ -8,10 +8,10 @@ class NetworkTransaction;
 
 typedef QMap<QString, QString> ParamMap;
 
-class JsonObject : public ParamMap
+class ImgurResponse : public ParamMap
 {
 public:
-	JsonObject(const NetworkTransaction &tr);
+	ImgurResponse(const NetworkTransaction &tr);
 	void debug() const;
 
 	ParamMap data;


### PR DESCRIPTION
Qt Script was only used to evaluate JSON responses as JavaScript in order to parse them. There are better ways to do so. Qt provides a set of classes for reading and writing JSONs, which have been used instead of Qt Script in this pull request.

Also, Qt Script is deprecated and removed in Qt 6.